### PR TITLE
refactor: replace swashbuckle with openapi and scalar

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,8 +15,9 @@
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.12.39" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
     <PackageVersion Include="System.DirectoryServices" Version="10.0.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ This project targets net 10.0. For previous versions, check the tags. The follow
 
 - [Carter](https://github.com/CarterCommunity/Carter)
 - [Xunit.v3](https://github.com/xunit/xunit)
-- [Swashbuckle.AspNetCore](https://github.com/domaindrivendev/Swashbuckle.AspNetCore)
-- [Serilog.AspNetCore](https://github.com/serilog/serilog-aspnetcore/)
+- [Scalar.AspNetCore](https://github.com/scalar/scalar)
+- [Serilog.AspNetCore](https://github.com/serilog/serilog-aspnetcore)
 
 [github-main-img]: https://github.com/Jaxelr/ActiveDirectory/actions/workflows/ci.yml/badge.svg
 [github-main]: https://github.com/Jaxelr/ActiveDirectory/actions/workflows/ci.yml

--- a/src/ActiveDirectory.csproj
+++ b/src/ActiveDirectory.csproj
@@ -20,8 +20,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
+    <PackageReference Include="Scalar.AspNetCore" />
     <PackageReference Include="Serilog.AspNetCore" />
-    <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="System.DirectoryServices" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Extensions/SwaggerExtensions.cs
+++ b/src/Extensions/SwaggerExtensions.cs
@@ -1,8 +1,8 @@
 using ActiveDirectory.Models.Internal;
-using Carter.OpenApi;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi;
+using Scalar.AspNetCore;
 
 namespace ActiveDirectory.Extensions;
 
@@ -10,39 +10,28 @@ public static class SwaggerExtensions
 {
     private const string ServiceName = "Active Directory";
 
-    public static WebApplicationBuilder AddSwagger(this WebApplicationBuilder builder, AppSettings settings)
+    public static WebApplicationBuilder AddOpenApi(this WebApplicationBuilder builder, AppSettings settings)
     {
-        //Swagger
-        builder.Services.AddEndpointsApiExplorer();
-        builder.Services.AddSwaggerGen(options =>
+        builder.Services.AddOpenApi(settings.RouteDefinition.Version, options =>
         {
-            options.SwaggerDoc(settings.RouteDefinition.Version, new OpenApiInfo
+            options.AddDocumentTransformer((document, _, _) =>
             {
-                Description = ServiceName,
-                Version = settings.RouteDefinition.Version,
-            });
-
-            options.DocInclusionPredicate((_, description) =>
-            {
-                foreach (object metaData in description.ActionDescriptor.EndpointMetadata)
+                document.Info = new OpenApiInfo
                 {
-                    if (metaData is IIncludeOpenApi)
-                    {
-                        return true;
-                    }
-                }
-                return false;
+                    Description = ServiceName,
+                    Version = settings.RouteDefinition.Version,
+                };
+                return System.Threading.Tasks.Task.CompletedTask;
             });
         });
 
         return builder;
     }
 
-    public static WebApplication UseSwagger(this WebApplication app, AppSettings _)
+    public static WebApplication UseOpenApi(this WebApplication app, AppSettings settings)
     {
-        app.UseSwagger();
-        app.UseSwaggerUI();
-
+        app.MapOpenApi($"{settings.RouteDefinition.Resource}/{settings.RouteDefinition.Version}.json");
+        app.MapScalarApiReference($"{settings.RouteDefinition.Resource}");
         return app;
     }
 }

--- a/src/Models/Internal/RouteDefinition.cs
+++ b/src/Models/Internal/RouteDefinition.cs
@@ -2,6 +2,6 @@ namespace ActiveDirectory.Models.Internal;
 
 public record RouteDefinition
 {
-    public string RouteSuffix { get; init; } = string.Empty;
+    public string Resource { get; init; } = string.Empty;
     public string Version { get; init; } = string.Empty;
 }

--- a/src/Modules/MainModule.cs
+++ b/src/Modules/MainModule.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using ActiveDirectory.Models.Internal;
 using Carter;
 using Microsoft.AspNetCore.Builder;
@@ -12,7 +12,7 @@ public class MainModule : ICarterModule
     public void AddRoutes(IEndpointRouteBuilder app) =>
         app.MapGet("/", (AppSettings settings, HttpContext ctx) =>
         {
-            ctx.Response.Redirect(settings.RouteDefinition.RouteSuffix);
+            ctx.Response.Redirect(settings.RouteDefinition.Resource);
             return Task.CompletedTask;
         });
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -33,7 +33,7 @@ var _ = (settings.Domains.Empty()) ?
 
 builder.AddHealthChecks();
 
-builder.AddSwagger(settings);
+builder.AddOpenApi(settings);
 
 var app = builder.Build();
 
@@ -51,7 +51,7 @@ else
 app.UseHttpsRedirection();
 app.UseRouting();
 
-app.UseSwagger(settings);
+app.UseOpenApi(settings);
 
 app.UseHealthChecks();
 

--- a/src/appsettings.Development.json
+++ b/src/appsettings.Development.json
@@ -15,7 +15,7 @@
       "CacheEnabled": false
     },
     "RouteDefinition": {
-      "RouteSuffix": "/swagger",
+      "Resource": "openapi",
       "Version": "v1"
     },
     "Domains": [

--- a/src/appsettings.Development.json
+++ b/src/appsettings.Development.json
@@ -15,7 +15,7 @@
       "CacheEnabled": false
     },
     "RouteDefinition": {
-      "Resource": "openapi",
+      "Resource": "/openapi",
       "Version": "v1"
     },
     "Domains": [

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -15,7 +15,7 @@
       "CacheEnabled": true
     },
     "RouteDefinition": {
-      "RouteSuffix": "/swagger",
+      "Resource": "/openapi",
       "Version": "v1"
     },
     "Domains": [


### PR DESCRIPTION
# Description

This PR replaces the actual utilization of swashbuckle aspnetcore with ms.openapi and adds the scalar ui for doc generation.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings